### PR TITLE
Use the absolute path to babel preset

### DIFF
--- a/lib/compilers/babel-compiler.js
+++ b/lib/compilers/babel-compiler.js
@@ -4,7 +4,7 @@ const logger = require('../logger')
 const cache = require('../cache')
 
 var defaultBabelOptions = {
-  presets: ['vue-app']
+  presets: [require.resolve('babel-preset-vue-app')]
 }
 
 function getBabelConfig () {


### PR DESCRIPTION
let babel use the built-in babel preset instead of looking for it in current working directory (may not exist).