### PR TITLE
Process functional single file components

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -21,8 +21,25 @@ function processScript (scriptPart) {
   return compileBabel(scriptPart.content)
 }
 
+function isFunctionalTemplate (parts) {
+  try {
+    if (parts.template.attrs.functional === true) return true
+  } catch (error) {
+    return false
+  }
+}
+
+function changePartsIfFunctional (parts) {
+  if (isFunctionalTemplate(parts)) {
+    parts.lang = 'javascript'
+    parts.script = { type: 'script', content: 'export default { props: { props: Object } }' }
+  }
+}
+
 module.exports = function (src, path) {
   var parts = vueCompiler.parseComponent(src, { pad: true })
+
+  changePartsIfFunctional(parts)
 
   const result = processScript(parts.script)
   const script = result.code

--- a/test/FunctionalSFC.spec.js
+++ b/test/FunctionalSFC.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'vue-test-utils'
+import FunctionalSFC from './resources/FunctionalSFC.vue'
+
+test('processes .vue file with functional template', () => {
+  const wrapper = shallow(FunctionalSFC, {
+    propsData: { props: { msg: 'Hello' }}
+  })
+  expect(wrapper.is('div')).toBe(true)
+  expect(wrapper.text().trim()).toBe('Hello')
+})

--- a/test/resources/FunctionalSFC.vue
+++ b/test/resources/FunctionalSFC.vue
@@ -1,0 +1,5 @@
+<template functional>
+    <div class="hello">
+        {{ props.msg }}
+    </div>
+</template>


### PR DESCRIPTION
Vue supports Pure Functional templates from version 2.5:
https://vue-loader.vuejs.org/en/features/functional.html

With this pull request jest-vue would allow them to be tested.

* Note that we need to nest props attribute in propsData like this:

```
const wrapper = shallow(FunctionalSFC, {
    propsData: { props: { msg: 'Hello' }}
 })
```